### PR TITLE
This simply unlinks the 'package_subproject_list.cmake' temporary cre…

### DIFF
--- a/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
+++ b/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
@@ -207,6 +207,7 @@ Set CWD = /dev/null/workspace
                 l_environ, \
                 mock.patch('PullRequestLinuxDriverTest.createPackageEnables'), \
                 mock.patch('PullRequestLinuxDriverTest.setBuildEnviron'), \
+                mock.patch('PullRequestLinuxDriverTest.compute_n', return_value=20), \
                 mock.patch('PullRequestLinuxDriverTest.getCDashTrack') as m_cdtr:
             PullRequestLinuxDriverTest.run()
 
@@ -319,14 +320,16 @@ class Test_createPackageEnables(unittest.TestCase):
 
     def success_side_effect(self):
         with open('packageEnables.cmake',  'w') as f_out:
-            f_out.write('''
-MACRO(PR_ENABLE_BOOL  VAR_NAME  VAR_VAL)
-  MESSAGE("-- Setting ${VAR_NAME} = ${VAR_VAL}")
-  SET(${VAR_NAME} ${VAR_VAL} CACHE BOOL "Set in $CMAKE_PACKAGE_ENABLES_OUT")
-ENDMACRO()
-''')
+            f_out.write(dedent('''\
+            MACRO(PR_ENABLE_BOOL  VAR_NAME  VAR_VAL)
+              MESSAGE("-- Setting ${VAR_NAME} = ${VAR_VAL}")
+              SET(${VAR_NAME} ${VAR_VAL} CACHE BOOL "Set in $CMAKE_PACKAGE_ENABLES_OUT")
+            ENDMACRO()
+            '''))
             f_out.write("PR_ENABLE_BOOL(Trilinos_ENABLE_FooPackageBar ON)")
-
+        with open ('package_subproject_list.cmake', 'w') as f_out:
+            f_out.write(dedent('''\
+            set(CTEST_LABELS_FOR_SUBPROJECTS TrilinosFrameworkTests '''))
 
     def test_call_success(self):
         expected_output = '''Enabled packages:
@@ -349,6 +352,7 @@ ENDMACRO()
                                        'package_subproject_list.cmake'])
         self.assertEqual(expected_output, m_stdout.getvalue())
         os.unlink('packageEnables.cmake')
+        os.unlink('package_subproject_list.cmake')
 
 
     def test_call_python2(self):
@@ -366,6 +370,7 @@ ENDMACRO()
         m_out.assert_not_called()
         self.assertEqual(expected_output, m_stdout.getvalue())
         os.unlink('packageEnables.cmake')
+        os.unlink('package_subproject_list.cmake')
 
 
     def test_call_failure(self):


### PR DESCRIPTION
…ated during testing

I also repaired an issue that only showed up on smaller
machines that what the PR testing runs on (my laptop
in this case.)