### PR TITLE
Add release notes for Trilinos 14.0 and break in backward compatibility with -isystem include dirs

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,80 @@
 ###############################################################################
 #                                                                             #
+# Trilinos Release 14.0 Release Notes                                         #
+#                                                                             #
+###############################################################################
+
+CMake
+
+  - Switch to modern CMake targets in IMPORTED library targets in installed
+    <Package>Config.cmake files
+
+    With switch to modern CMake IMPORTED targets, now include directories and
+    critical compiler options and include directories (and other modern CMake
+    usage requirements) are propagated through linking to the IMPORTED library
+    targets in downstream customer CMake projects.  This makes the usage of
+    the variables `<Trilinos>_INCLUDE_DIRS` and `Trilinos__TPL_INCLUDE_DIRS`
+    unnecessary in downstream CMake projects.  However, this change will also
+    cause downstream CMake projects to pull in include directories as `SYSTEM`
+    (e.g. using `-isystem` instead of `-I`) from IMPORTED library targets.
+    This changes how these include directories are searched and could break
+    some fragile build environments that have the same header file names in
+    multiple include directories searched by the compiler.  Also, this will
+    silence any regular compiler warnings from headers found under these
+    include directories.  **This constitutes a break in backward compatibility
+    that will break some customer CMake project builds that uses Trilinos on
+    fragile environments where the search order of the include directories is
+    important.
+
+    There are several approaches for address this change from `-I` to
+    `-isystem` for the Trilinos include directories.
+
+    **Approach-1:** Update to CMake 3.23 and set the Trilinos configure
+    variable:
+
+      -D Trilinos_IMPORTED_NO_SYSTEM=ON
+
+    This will change back the listing of Trilinos include directories in
+    downstream customer CMake projects from `-isystem` and `-I` and will
+    therefore restore about perfect backward compatibility.
+
+    **Approach-2:** Set the cache variable
+    `CMAKE_NO_SYSTEM_FROM_IMPORTED=TRUE` downstream CMake project to set which
+    will restore the include directories for the IMPORTED library targets for
+    the TriBITS project as non-SYSTEM include directories (i.e. `-I`) but it
+    will also cause all include directories for all IMPORTED library targets
+    to be non-SYSTEM (i.e. `-I`) even if they were being handled as SYSTEM
+    include directories before.  Therefore, that could still break the
+    downstream project as it might change what header files are found for
+    these other IMPORTED library targets and may expose many new warnings
+    (which may have been silenced by their include directories being pulled in
+    using `-isystem`).
+
+    **Approach-3:** Clean up the list of include directories that is searched
+    by the compiler so that only the correct header files can be found
+    (regardless of the search order).
+
+    **Approach-4:** Delete some header files in set of searched include
+    directories so that only the correct header files can be found (regardless
+    of the search order).
+
+    **Approach-5:** Use other approaches more specific to the given customer
+    project.  For example, if multiple different versions of the googletest
+    (gtest) library header files can be found in the list of include
+    directories, then a customer project can build its own version of
+    googletest and put it's include directories first on the compile line and
+    list them with `-I` to ensure that only that version will be found, no
+    matter how many other versions of gtest are installed on the system.  For
+    example, see how this was done for one customer CMake project, see
+    https://github.com/trilinos/Trilinos/issues/8001#issuecomment-1032827124.
+
+    For more details on this change in the handling of include directories
+    with the switch to modern CMake, see
+    https://github.com/TriBITSPub/TriBITS/issues/443.
+
+
+###############################################################################
+#                                                                             #
 # Trilinos Release 12.12 Release Notes                                        #
 #                                                                             #
 ###############################################################################

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -7,27 +7,27 @@
 CMake
 
   - Switch to modern CMake targets in IMPORTED library targets in installed
-    <Package>Config.cmake files
+    <Package>Config.cmake files which breaks backward compatibility
 
-    With switch to modern CMake IMPORTED targets, now include directories and
-    critical compiler options and include directories (and other modern CMake
-    usage requirements) are propagated through linking to the IMPORTED library
+    With the switch to modern CMake IMPORTED targets, now include directories
+    (along with critical compiler options and other modern CMake usage
+    requirements) are propagated through linking to the IMPORTED library
     targets in downstream customer CMake projects.  This makes the usage of
-    the variables `<Trilinos>_INCLUDE_DIRS` and `Trilinos__TPL_INCLUDE_DIRS`
+    the variables `<Trilinos>_INCLUDE_DIRS` and `Trilinos_TPL_INCLUDE_DIRS`
     unnecessary in downstream CMake projects.  However, this change will also
     cause downstream CMake projects to pull in include directories as `SYSTEM`
-    (e.g. using `-isystem` instead of `-I`) from IMPORTED library targets.
-    This changes how these include directories are searched and could break
-    some fragile build environments that have the same header file names in
-    multiple include directories searched by the compiler.  Also, this will
-    silence any regular compiler warnings from headers found under these
-    include directories.  **This constitutes a break in backward compatibility
-    that will break some customer CMake project builds that uses Trilinos on
-    fragile environments where the search order of the include directories is
-    important.
+    includes (e.g. using `-isystem` instead of `-I`) from IMPORTED library
+    targets.  This changes how these include directories are searched and
+    could break some fragile build environments that have the same header file
+    names in multiple include directories searched by the compiler.  Also,
+    this will silence any regular compiler warnings from headers found under
+    these include directories.  This constitutes a **break in backward
+    compatibility** that will break some customer CMake project builds that
+    use Trilinos on fragile environments where the search order of the include
+    directories is important.
 
-    There are several approaches for address this change from `-I` to
-    `-isystem` for the Trilinos include directories.
+    There are several different approaches for addressing this change from
+    `-I` to `-isystem` for the Trilinos include directories described below.
 
     **Approach-1:** Update to CMake 3.23 and set the Trilinos configure
     variable:
@@ -39,22 +39,22 @@ CMake
     therefore restore about perfect backward compatibility.
 
     **Approach-2:** Set the cache variable
-    `CMAKE_NO_SYSTEM_FROM_IMPORTED=TRUE` downstream CMake project to set which
-    will restore the include directories for the IMPORTED library targets for
-    the TriBITS project as non-SYSTEM include directories (i.e. `-I`) but it
-    will also cause all include directories for all IMPORTED library targets
-    to be non-SYSTEM (i.e. `-I`) even if they were being handled as SYSTEM
-    include directories before.  Therefore, that could still break the
-    downstream project as it might change what header files are found for
-    these other IMPORTED library targets and may expose many new warnings
-    (which may have been silenced by their include directories being pulled in
-    using `-isystem`).
+    `CMAKE_NO_SYSTEM_FROM_IMPORTED=TRUE` in a downstream CMake project to set
+    which will restore the include directories for the IMPORTED library
+    targets for the TriBITS project as non-SYSTEM include directories
+    (i.e. `-I`) but it will also cause all include directories for all
+    IMPORTED library targets to be non-SYSTEM (i.e. `-I`) even if they were
+    being handled as SYSTEM include directories before.  Therefore, that could
+    still break the downstream project as it might change what header files
+    are found for these other IMPORTED library targets and may expose many new
+    warnings (which may have been silenced by their include directories being
+    pulled in using `-isystem`).
 
     **Approach-3:** Clean up the list of include directories that is searched
     by the compiler so that only the correct header files can be found
     (regardless of the search order).
 
-    **Approach-4:** Delete some header files in set of searched include
+    **Approach-4:** Delete some header files in the set of searched include
     directories so that only the correct header files can be found (regardless
     of the search order).
 
@@ -65,7 +65,7 @@ CMake
     googletest and put it's include directories first on the compile line and
     list them with `-I` to ensure that only that version will be found, no
     matter how many other versions of gtest are installed on the system.  For
-    example, see how this was done for one customer CMake project, see
+    an example of how this was done for one customer CMake project, see
     https://github.com/trilinos/Trilinos/issues/8001#issuecomment-1032827124.
 
     For more details on this change in the handling of include directories


### PR DESCRIPTION
Related TriBITS PRs are:

* TriBITSPub/TriBITS#456
* TriBITSPub/TriBITS#459

For more details, see TriBITSPub/TriBITS#443