### PR TITLE
Attempt by Claude 3.7 Sonnet to Extract Function

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3532,6 +3532,17 @@ public:
     ///   3. Call fillComplete on the destination matrix
     ///
     /// Fusing these tasks can avoid some communication and work.
+    /// \brief Helper method to extract parameters from the parameter list in transferAndFillComplete
+    void
+    transferAndFillComplete_getParameters (bool& isMM,
+                                          bool& reverseMode,
+                                          bool& restrictComm,
+                                          int& mm_optimization_core_count,
+                                          Teuchos::RCP<Teuchos::ParameterList>& matrixparams,
+                                          bool& overrideAllreduce,
+                                          bool& useKokkosPath,
+                                          const Teuchos::RCP<Teuchos::ParameterList>& params) const;
+
     void
     transferAndFillComplete (Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& destMatrix,
                              const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -9270,6 +9270,8 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   TPETRA_CRSMATRIX_IMPORT_AND_FILL_COMPLETE_INSTANT_TWO(SCALAR, LO, GO, NODE) \
   TPETRA_CRSMATRIX_EXPORT_AND_FILL_COMPLETE_INSTANT_TWO(SCALAR, LO, GO, NODE)
 
+namespace Tpetra {
+
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void
 CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
@@ -9282,6 +9284,7 @@ transferAndFillComplete_getParameters (bool& isMM,
                                        bool& useKokkosPath,
                                        const Teuchos::RCP<Teuchos::ParameterList>& params) const
 {
+  using Details::Behavior;
   using Teuchos::ParameterList;
   using Teuchos::RCP;
   using Teuchos::sublist;
@@ -9311,5 +9314,7 @@ transferAndFillComplete_getParameters (bool& isMM,
     if(reverseMode) isMM = false;
   }
 }
+
+} // namespace Tpetra
 
 #endif // TPETRA_CRSMATRIX_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -7743,25 +7743,16 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     bool isMM = false; // optimize for matrix-matrix ops.
     bool reverseMode = false; // Are we in reverse mode?
     bool restrictComm = false; // Do we need to restrict the communicator?
-
-    int mm_optimization_core_count =
-      Behavior::TAFC_OptimizationCoreCount();
+    int mm_optimization_core_count = 0;
     RCP<ParameterList> matrixparams; // parameters for the destination matrix
     bool overrideAllreduce = false;
     bool useKokkosPath = false;
-    if (! params.is_null ()) {
-      matrixparams = sublist (params, "CrsMatrix");
-      reverseMode = params->get ("Reverse Mode", reverseMode);
-      useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
-      restrictComm = params->get ("Restrict Communicator", restrictComm);
-      auto & slist = params->sublist("matrixmatrix: kernel params",false);
-      isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
-      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-
-      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
-      if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
-      if(reverseMode) isMM = false;
-    }
+    
+    // Extract parameters using the helper function
+    transferAndFillComplete_getParameters(isMM, reverseMode, restrictComm, 
+                                          mm_optimization_core_count,
+                                          matrixparams, overrideAllreduce,
+                                          useKokkosPath, params);
 
    // Only used in the sparse matrix-matrix multiply (isMM) case.
    std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
@@ -9278,5 +9269,47 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   TPETRA_CRSMATRIX_EXPORT_AND_FILL_COMPLETE_INSTANT(SCALAR, LO, GO, NODE) \
   TPETRA_CRSMATRIX_IMPORT_AND_FILL_COMPLETE_INSTANT_TWO(SCALAR, LO, GO, NODE) \
   TPETRA_CRSMATRIX_EXPORT_AND_FILL_COMPLETE_INSTANT_TWO(SCALAR, LO, GO, NODE)
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+transferAndFillComplete_getParameters (bool& isMM,
+                                       bool& reverseMode,
+                                       bool& restrictComm,
+                                       int& mm_optimization_core_count,
+                                       Teuchos::RCP<Teuchos::ParameterList>& matrixparams,
+                                       bool& overrideAllreduce,
+                                       bool& useKokkosPath,
+                                       const Teuchos::RCP<Teuchos::ParameterList>& params) const
+{
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::sublist;
+
+  // Initialize parameters with defaults
+  isMM = false; // optimize for matrix-matrix ops.
+  reverseMode = false; // Are we in reverse mode?
+  restrictComm = false; // Do we need to restrict the communicator?
+
+  mm_optimization_core_count =
+    Behavior::TAFC_OptimizationCoreCount();
+  matrixparams = Teuchos::null; // parameters for the destination matrix
+  overrideAllreduce = false;
+  useKokkosPath = false;
+
+  if (! params.is_null ()) {
+    matrixparams = sublist (params, "CrsMatrix");
+    reverseMode = params->get ("Reverse Mode", reverseMode);
+    useKokkosPath = params->get ("TAFC: use kokkos path", useKokkosPath);
+    restrictComm = params->get ("Restrict Communicator", restrictComm);
+    auto & slist = params->sublist("matrixmatrix: kernel params",false);
+    isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
+    mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
+
+    overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
+    if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
+    if(reverseMode) isMM = false;
+  }
+}
 
 #endif // TPETRA_CRSMATRIX_DEF_HPP


### PR DESCRIPTION
The prompt I used was:

----

Perform the Extract Function refactoring by creating a new function a called CrsMatrix::transferAndFillComplete_getParameters() for the lines 7740 through 7780 in the file packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp and update the function CrsMatrix::transferAndFillComplete() to call the new extracted function.

First, test that this code will build by running the command:

```
time ninja packages/tpetra/core/src/CMakeFiles/tpetra.dir/Tpetra_CrsMatrix_DOUBLE_DOUBLE_INT_LONG_LONG_SERIAL.cpp.o
```

from the build directory `BUILDS/clang-19/`.  Don't move on until this file builds without error.

Once that object file builds successfully, build one of the tests that uses this file by running:

```
time ninja packages/tpetra/core/test/CrsMatrix/TpetraCore_CrsMatrix_UnitTests.exe
```

Once that test builds, run the test as:

```
time ctest  -R "^TpetraCore_CrsMatrix_UnitTests$"
```

The output from that command will provide the full test output.

----

That ended up stopping and asking me to fix the code.

The first build error was:

```
/home/rabartl/Trilinos.base/Trilinos/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp:9275:1: error: no template named 'CrsMatrix'
 9275 | CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
      | ^
```

It did not even put the template function in the namespace properly.  Claude 3.7 Sonnet is pretty dumb.

However, I did add a commit to fix the build errors.
